### PR TITLE
add auto-loader for zen_href_link

### DIFF
--- a/files/includes/auto_loaders/config.ceon_href_link_loader.php
+++ b/files/includes/auto_loaders/config.ceon_href_link_loader.php
@@ -1,0 +1,15 @@
+<?php
+
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+
+$autoLoadConfig[0][] = array(
+    'autoType' => 'class',
+    'loadFile' => 'observers/class.ceon_uri_mapping_link_build_observer.php'	
+    );
+$autoLoadConfig[165][] = array(
+    'autoType' => 'classInstantiate',
+    'className' => 'CeonUriMappingLinkBuild',
+    'objectName' => 'ceon_uri_mapping_link_build_observe'
+);

--- a/files/includes/classes/observers/class.ceon_uri_mapping_link_build_observer.php
+++ b/files/includes/classes/observers/class.ceon_uri_mapping_link_build_observer.php
@@ -13,7 +13,7 @@
  * @license     http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version     2016
  */
-class zcObserverCeonUriMappingLinkBuild extends base
+class CeonUriMappingLinkBuild extends base
 {
     function __construct()
     {
@@ -26,7 +26,7 @@ class zcObserverCeonUriMappingLinkBuild extends base
     function update(&$callingClass, $notifier, $p1, &$link, $page, $parameters, $connection, $add_session_id, $static, &$use_dir_ws_catalog)//& required for &$link to modify it inside here
 
     {
-        if (defined('CEON_URI_MAPPING_ENABLED') && CEON_URI_MAPPING_ENABLED == 1 && $static == false) {
+        if (defined('CEON_URI_MAPPING_ENABLED') && CEON_URI_MAPPING_ENABLED === '1' && $static == false) {
 
             if (!isset($ceon_uri_mapping_href_link_builder)) {
                 //static $ceon_uri_mapping_href_link_builder;//steve not needed/overwritten immediately


### PR DESCRIPTION
For a default install of ZC 1.5.5 to then incorporate Ceon URI Mapping,
one of the core files is loaded before the observer auto loader.
As such, that file does not offer the expected uri rewriting.
Two options: either the ZC load sequence is modified to support
the auto loader style and the rewriting (with unknown effect on other plugins
that do not require such a swap, or the guidance within
includes/init_includes/init_observe.php is followed and the necessary
code is used instead of the auto observer system. Ultimately, the problem
is that the core loadPoint is not in the sequence to support full rewrite
capability because the observer for the url function needs to be executed
before the breadcrumbs.

This applies three changes that involve 2 "new" files and basically
modification/removal of an existing file.

This supports loading the observer for monitoring the
function zen_href_link so that the sequence of core files does not
need to be modified. While that may happen independent of this change,
it is no reason to modify or require others to modify their core code.