### PR TITLE
Move of non-product general

### DIFF
--- a/modified_core_files/1.5.5b/ADMIN_YOURS/includes/modules/move_product_confirm.php
+++ b/modified_core_files/1.5.5b/ADMIN_YOURS/includes/modules/move_product_confirm.php
@@ -37,8 +37,8 @@ if (!defined('IS_ADMIN_FLAG')) {
           
           $ceon_uri_mapping_admin = new CeonURIMappingAdminProductPages();
           
-          $ceon_uri_mapping_admin->moveProductConfirmHandler($products_id, $product_type,
-            $zc_products->get_handler($product_type), $new_parent_id);
+          $ceon_uri_mapping_admin->moveProductConfirmHandler($products_id, zen_get_products_type($products_id),
+            $zc_products->get_handler(zen_get_products_type($products_id)), $new_parent_id);
           
           // END CEON URI MAPPING 1 of 1
           // reset products_price_sorter for searches etc.


### PR DESCRIPTION
When a product is of product type product_general (product page of product_info), then when selecting to move the product from within the catalog screen works fine because it is product type 1; however, if the product is of a different product type (document general or other product type), then the generated uri for the product is reported as being product_type and the associated handler for that product type.

The above modification uses the current $products_id to determine both the product type and handler for the product being moved as it is not otherwise set at this point in the product move.